### PR TITLE
chore: `cspell`: use `--locale` instead of `--language-id`

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 		"test:unit": "vitest",
 		"test:ui": "vitest --ui",
 		"test:ci": "vitest run",
-		"cspell": "cspell '**/*.md' --config cspell.json --language-id en-gb --wordsOnly",
+		"cspell": "cspell '**/*.md' --config cspell.json --locale en-gb --wordsOnly",
 		"contributors:add": "all-contributors add",
 		"contributors:generate": "all-contributors generate"
 	},


### PR DESCRIPTION
`--langauge-id` is used to set the file type. (It is a confusing name and should be changed.)

`cspell lint --help`

```
  --locale <locale>            Set language locales. i.e. "en,fr" for English and French, or "en-GB" for
                               British English.
  --language-id <language>     Force programming language for unknown extensions. i.e. "php" or "scala"
```