### PR TITLE
feat(tweet): darkmode support

### DIFF
--- a/apps/web/src/routes/+page.md
+++ b/apps/web/src/routes/+page.md
@@ -646,6 +646,7 @@ Props:
 
 ```ts
 tweetLink: string = '';
+theme: string = 'dark' | 'light' = 'light';
 ```
 
 Usage:
@@ -659,7 +660,10 @@ Usage:
 
 Output:
 
-<Tweet tweetLink="adamwathan/status/959078631434731521" />
+<Tweet 
+  tweetLink="adamwathan/status/959078631434731521" 
+  theme="dark"
+/>
 
 ## Vimeo
 

--- a/apps/web/src/routes/+page.md
+++ b/apps/web/src/routes/+page.md
@@ -651,7 +651,10 @@ tweetLink: string = '';
 Usage:
 
 ```html
-<Tweet tweetLink="adamwathan/status/959078631434731521" />
+<Tweet
+	tweetLink="adamwathan/status/959078631434731521"
+	theme="dark"
+/>
 ```
 
 Output:

--- a/packages/sveltekit-embed/src/lib/components/tweet.svelte
+++ b/packages/sveltekit-embed/src/lib/components/tweet.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
 	interface Props {
 		tweetLink?: string;
+		isDarkMode?: boolean;
 	}
 
-	let { tweetLink = '' }: Props = $props();
+	let { tweetLink = '', isDarkMode = false }: Props = $props();
 
 	let twitter_widgets_script: HTMLScriptElement | null = null;
 
@@ -32,7 +33,10 @@
 </script>
 
 <div class="tweet-wrapper">
-	<blockquote class="twitter-tweet">
+	<blockquote
+		class="twitter-tweet"
+		data-theme={isDarkMode ? 'dark' : null}
+	>
 		<a href={`https://twitter.com/${tweetLink}`}>Loading Tweet...</a>
 	</blockquote>
 </div>

--- a/packages/sveltekit-embed/src/lib/components/tweet.svelte
+++ b/packages/sveltekit-embed/src/lib/components/tweet.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
 	interface Props {
 		tweetLink?: string;
-		isDarkMode?: boolean;
+		theme?: 'light' | 'dark';
 	}
 
-	let { tweetLink = '', isDarkMode = false }: Props = $props();
+	let { tweetLink = '', theme = 'light' }: Props = $props();
 
 	let twitter_widgets_script: HTMLScriptElement | null = null;
 
@@ -33,10 +33,7 @@
 </script>
 
 <div class="tweet-wrapper">
-	<blockquote
-		class="twitter-tweet"
-		data-theme={isDarkMode ? 'dark' : null}
-	>
+	<blockquote class="twitter-tweet" data-theme={theme}>
 		<a href={`https://twitter.com/${tweetLink}`}>Loading Tweet...</a>
 	</blockquote>
 </div>

--- a/packages/sveltekit-embed/src/lib/components/tweet.svelte
+++ b/packages/sveltekit-embed/src/lib/components/tweet.svelte
@@ -45,23 +45,16 @@
 </div>
 
 <style>
-	:root {
-		--twitter-embed-bg-light: #ffffff;
-		--twitter-embed-bg-dark: #151d26;
-	}
-
 	.tweet-wrapper {
 		display: flex;
 		justify-content: center;
 		margin-bottom: 12px;
+		border-radius: 13px;
+		overflow: hidden;
 	}
 
-	.tweet-wrapper[data-theme='light'][data-loaded='true'] {
-		background-color: var(--twitter-embed-bg-light);
-	}
-
-	.tweet-wrapper[data-theme='dark'][data-loaded='true'] {
-		background-color: var(--twitter-embed-bg-dark);
+	.tweet-wrapper :global(iframe) {
+		border-radius: 13px !important;
 	}
 
 	.twitter-tweet {

--- a/packages/sveltekit-embed/src/lib/components/tweet.svelte
+++ b/packages/sveltekit-embed/src/lib/components/tweet.svelte
@@ -6,7 +6,9 @@
 
 	let { tweetLink = '', theme = 'light' }: Props = $props();
 
-	let twitter_widgets_script: HTMLScriptElement | null = null;
+	let twitter_widgets_script = $state.raw<HTMLScriptElement | null>(
+		null,
+	);
 
 	const load_twitter_widgets_script = () => {
 		if (twitter_widgets_script) return;
@@ -32,17 +34,34 @@
 	});
 </script>
 
-<div class="tweet-wrapper">
+<div
+	class="tweet-wrapper"
+	data-theme={theme}
+	data-loaded={twitter_widgets_script != null}
+>
 	<blockquote class="twitter-tweet" data-theme={theme}>
 		<a href={`https://twitter.com/${tweetLink}`}>Loading Tweet...</a>
 	</blockquote>
 </div>
 
 <style>
+	:root {
+		--twitter-embed-bg-light: #ffffff;
+		--twitter-embed-bg-dark: #151d26;
+	}
+
 	.tweet-wrapper {
 		display: flex;
 		justify-content: center;
 		margin-bottom: 12px;
+	}
+
+	.tweet-wrapper[data-theme='light'][data-loaded='true'] {
+		background-color: var(--twitter-embed-bg-light);
+	}
+
+	.tweet-wrapper[data-theme='dark'][data-loaded='true'] {
+		background-color: var(--twitter-embed-bg-dark);
 	}
 
 	.twitter-tweet {

--- a/packages/sveltekit-embed/src/lib/components/tweet.svelte
+++ b/packages/sveltekit-embed/src/lib/components/tweet.svelte
@@ -11,7 +11,16 @@
 	);
 
 	const load_twitter_widgets_script = () => {
+		if (
+			document.querySelector(
+				'script[src*="platform.twitter.com/widgets.js"]',
+			)
+		) {
+			return;
+		}
+
 		if (twitter_widgets_script) return;
+
 		twitter_widgets_script = document.createElement('script');
 		twitter_widgets_script.src =
 			'https://platform.twitter.com/widgets.js';
@@ -20,13 +29,12 @@
 	};
 
 	const remove_twitter_widget_script = () => {
-		if (twitter_widgets_script) {
-			document.head.removeChild(twitter_widgets_script);
-			twitter_widgets_script = null;
-		}
+		if (!twitter_widgets_script) return;
+		document.head.removeChild(twitter_widgets_script);
+		twitter_widgets_script = null;
 	};
 
-	$effect(() => {
+	$effect.root(() => {
 		load_twitter_widgets_script();
 		return () => {
 			remove_twitter_widget_script();


### PR DESCRIPTION
According [this page](https://devcommunity.x.com/t/embedded-tweets-night-mode/109244), we can embed twitter card in night mode using `data-theme='dark'`