### PR TITLE
fix: (and improve) YouTube component behavior with playlist

### DIFF
--- a/packages/sveltekit-embed/src/lib/components/you-tube.svelte
+++ b/packages/sveltekit-embed/src/lib/components/you-tube.svelte
@@ -5,6 +5,7 @@
 	interface Props {
 		youTubeId?: string;
 		listId?: string;
+		index?: number;
 		autoPlay?: boolean;
 		aspectRatio?: string;
 		skipTo?: any;
@@ -15,6 +16,7 @@
 	let {
 		youTubeId = '',
 		listId = '',
+		index = 0,
 		autoPlay = false,
 		aspectRatio = '16:9',
 		skipTo = { h: 0, m: 0, s: 0 },
@@ -37,7 +39,7 @@
 	const src = `${baseUrl}${
 		youTubeId.length > 0
 			? `${youTubeId}?autoplay=${autoPlay}&start=${startTime}`
-			: `?videoseries?list=${listId}`
+			: `?videoseries&list=${listId}&index=${index}&autoplay=${autoPlay}&start=${startTime}`
 	}`;
 </script>
 

--- a/packages/sveltekit-embed/src/lib/components/you-tube.test.ts
+++ b/packages/sveltekit-embed/src/lib/components/you-tube.test.ts
@@ -45,7 +45,7 @@ describe('YouTube', () => {
 			disable_observer: true,
 		});
 		const iframe = getByTitle(`youTube-${listId}`);
-		const expectedSrc = `https://www.youtube-nocookie.com/embed/?videoseries?list=${listId}`;
+		const expectedSrc = `https://www.youtube-nocookie.com/embed/?videoseries&list=${listId}&index=0&autoplay=false&start=0`;
 		expect(iframe.getAttribute('src')).toBe(expectedSrc);
 	});
 


### PR DESCRIPTION
fixes #775 

Playlists with listId weren't functionning.

- fix the src url construction for playlists + add an optional `index` prop (which playlist item to start)
- update unit tests